### PR TITLE
Updated fasta protein validation message

### DIFF
--- a/src/parsers/utils/validateSequence.js
+++ b/src/parsers/utils/validateSequence.js
@@ -65,7 +65,7 @@ module.exports = function validateSequence(sequence, {
         validChars = filterAminoAcidSequenceString(sequence.sequence);
         if (validChars !== sequence.sequence) {
             sequence.sequence = validChars;
-            response.messages.push("Import Error: Illegal character(s) detected and removed from amino acid sequence. Allowed characters are: galmfwkqespvicyhrnd");
+            response.messages.push("Import Error: Illegal character(s) detected and removed from amino acid sequence. Allowed characters are: xtgalmfwkqespvicyhrndu");
         }
         sequence.type = 'PROTEIN';
     } else {


### PR DESCRIPTION
Hello @tnrich 

The error message was a little outdated.
Updated the message with 'x', 't' and 'u'

Continuing issue https://github.com/TeselaGen/ve-sequence-utils/issues/5